### PR TITLE
Infinite scroll (#4095)

### DIFF
--- a/static/usage/v8/infinite-scroll/basic/vue.md
+++ b/static/usage/v8/infinite-scroll/basic/vue.md
@@ -23,7 +23,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -37,7 +36,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/basic/vue.md
+++ b/static/usage/v8/infinite-scroll/basic/vue.md
@@ -32,7 +32,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -98,7 +98,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -89,7 +89,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -103,7 +102,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
@@ -26,7 +26,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -40,7 +39,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
@@ -35,7 +35,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,


### PR DESCRIPTION
**Changelog**
1. Removed duplicate `IonContent` imports in Vue displays
2. Removed import and export of unused `IonImg` components in Vue displays
3. Demoed changes of modified components, all remain functional
4. Compiled and previewed modified docs site with changes, all remain functional

---
**Links**
- [Repository Branch](https://github.com/kkindrai/ionic-docs/tree/infinite-scroll) 
- [Issue #4095](https://github.com/ionic-team/ionic-docs/issues/4095)