### PR TITLE
Created Ionic Standalone Javascript Overview

### DIFF
--- a/docs/standalone-javascript/overview.md
+++ b/docs/standalone-javascript/overview.md
@@ -1,0 +1,35 @@
+---
+title: 'Ionic Standalone Javascript Overview'
+sidebar_label: Overview
+---
+
+<head>
+  <title>Ionic Standalone JavaScript Overview | Standalone Javascript Documentation</title>
+  <meta
+    name="description"
+    content="Read this overview to learn how to incorporate Ionic in your Web Development projects, without installing any frameworks."
+  />
+</head>
+
+import DocsCard from '@components/global/DocsCard';
+import DocsCards from '@components/global/DocsCards';
+
+`@ionic/core` brings the Ionic Experience to any project — no framework, no CLI.
+
+## Ionic Framework CDN
+
+Ionic Framework can be included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](https://codepen.io), or any other online code editor!
+
+It's recommended to use [jsdelivr](https://www.jsdelivr.com/) to access the Framework from a CDN. To get the latest version, add the following inside the `<head>` element in an HTML file, or where external assets are included in the online code editor:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+```
+
+ The CSS bundle will include all of the Ionic [Global Stylesheets](../layout/global-stylesheets).
+
+
+## Using Components
+To use Ionic Components, you can browse our [UI Components Library](../docs/components) and copy the `JavaScript` sample code. This code can then be modified for your purposes.

--- a/sidebars.js
+++ b/sidebars.js
@@ -179,6 +179,14 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Standalone JavaScript',
+      collapsed: false,
+      items: [
+        'standalone-javascript/overview',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Utilities',
       collapsed: false,
       items: ['utilities/animations', 'utilities/gestures'],


### PR DESCRIPTION
+ Modified sidebars.js to include navigation element for Standalone Javascript
+ Added a standalone-javascript/ directory
+ Added an overview.md to the standalone-javascript/ directory
+ Added documentation explaining how to import the required scripts to an html page <head> from ../docs/intro/cdn
+ Added short paragraph explaining how to access components

Original Issue: https://github.com/orgs/ionic-team/projects/22/views/1?pane=issue&itemId=111774305&issue=ionic-team%7Cionic-docs%7C2109
