### PR TITLE
docs(ion-item): added routerLink to Clickable

### DIFF
--- a/docs/api/item.md
+++ b/docs/api/item.md
@@ -163,7 +163,7 @@ import Controls from '@site/static/usage/v8/item/content-types/controls/index.md
 
 ## Clickable Items
 
-An item is considered "clickable" if it has an `href` or `button` property set. Clickable items have a few visual differences that indicate they can be interacted with. For example, a clickable item receives the ripple effect upon activation in `md` mode, has a highlight when activated in `ios` mode, and has a [detail arrow](#detail-arrows) by default in `ios` mode.
+An item is considered 'clickable' if it has an `href` or `button` property set, or if it uses a framework's [routerLink](https://ionicframework.com/docs/api/router-link) directive/component. Clickable items have a few visual differences that indicate they can be interacted with. For example, a clickable item receives the ripple effect upon activation in `md` mode, has a highlight when activated in `ios` mode, and has a [detail arrow](#detail-arrows) by default in `ios` mode.
 
 import Clickable from '@site/static/usage/v8/item/clickable/index.md';
 

--- a/static/usage/v8/item/clickable/demo.html
+++ b/static/usage/v8/item/clickable/demo.html
@@ -35,6 +35,10 @@
           <ion-item button disabled="true">
             <ion-label>Disabled Button Item</ion-label>
           </ion-item>
+
+          <ion-item router-link="#" router-direction="forward" onclick="alert('Navigating via JS!')" button>
+            <ion-label>Router Link</ion-label>
+          </ion-item>
         </div>
       </ion-content>
     </ion-app>

--- a/static/usage/v8/item/clickable/javascript.md
+++ b/static/usage/v8/item/clickable/javascript.md
@@ -12,9 +12,7 @@
 </ion-item>
 
 <!--
-  Note: The 'router-link' attribute requires a configured 
-  routing library like Ionic's Web Component router for navigation to occur.
-  Since this playground is a simplified snippet, 
+  Note: Since this playground is a simplified snippet, 
   clicking these items will not trigger navigation.
 -->
 <ion-item router-link="#" router-direction="forward" onclick="alert('Navigating via JS!')">

--- a/static/usage/v8/item/clickable/javascript.md
+++ b/static/usage/v8/item/clickable/javascript.md
@@ -11,7 +11,13 @@
   <ion-label>Button Item</ion-label>
 </ion-item>
 
-<ion-item button disabled="true">
-  <ion-label>Disabled Button Item</ion-label>
+<!--
+  Note: The 'router-link' attribute requires a configured 
+  routing library like Ionic's Web Component router for navigation to occur.
+  Since this playground is a simplified snippet, 
+  clicking these items will not trigger navigation.
+-->
+<ion-item router-link="#" router-direction="forward" onclick="alert('Navigating via JS!')">
+  <ion-label>Router Link</ion-label>
 </ion-item>
 ```


### PR DESCRIPTION
1. Added routerLink to item.md documentation
2. Insert where user can find routerLink within Clickable 
3. Created demonstration and code in playground on how routerLink can be used in Vanilla JavaScript.

Original Issue: [Issue #1852](https://github.com/ionic-team/ionic-docs/issues/1852)