### PR TITLE
bug: diff code blocks used but not supported (#4156)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -324,7 +324,7 @@ module.exports = {
     prism: {
       theme: { plain: {}, styles: [] },
       // https://github.com/FormidableLabs/prism-react-renderer/blob/e6d323332b0363a633407fabab47b608088e3a4d/packages/generate-prism-languages/index.ts#L9-L25
-      additionalLanguages: ['shell-session', 'http'],
+      additionalLanguages: ['shell-session', 'http', 'diff'],
     },
     algolia: {
       appId: 'O9QSL985BS',

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -175,6 +175,13 @@ pre[class*='language-'] {
   cursor: help;
 }
 
-.token.deleted {
-  color: red;
+// diff code block highlighting
+.language-diff .token.deleted {
+  color: rgb(50, 0, 0);
+  background-color: rgba(255, 0, 0, 0.05);
+}
+
+.language-diff .token.inserted {
+  color: darkgreen;
+  background-color: rgba(0, 255, 0, 0.05);
 }

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -175,6 +175,10 @@ pre[class*='language-'] {
   cursor: help;
 }
 
+.token.deleted {
+  color: red;
+}
+
 // diff code block highlighting
 .language-diff .token.deleted {
   color: rgb(50, 0, 0);

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -149,7 +149,8 @@ pre[class*='language-'] {
 .token.attr-value,
 .language-css .token.string,
 .style .token.string,
-.token.variable {
+.token.variable,
+.language-diff .token.inserted {
   color: #42b983;
 }
 
@@ -159,7 +160,8 @@ pre[class*='language-'] {
 
 .token.regex,
 .token.keyword,
-.token.important {
+.token.important,
+.language-diff .token.deleted {
   color: #f55073;
 }
 
@@ -177,15 +179,4 @@ pre[class*='language-'] {
 
 .token.deleted {
   color: red;
-}
-
-// diff code block highlighting
-.language-diff .token.deleted {
-  color: rgb(50, 0, 0);
-  background-color: rgba(255, 0, 0, 0.05);
-}
-
-.language-diff .token.inserted {
-  color: darkgreen;
-  background-color: rgba(0, 255, 0, 0.05);
 }


### PR DESCRIPTION
resolves https://github.com/ionic-team/ionic-docs/issues/4156

- Add 'diff' to list of additional languages supported in docusaurus.config.js.
- Add additional styles in styles/components/_code.scss for inserted and deleted lines in diff code blocks only.
<img width="475" alt="diffHighlightingFix" src="https://github.com/user-attachments/assets/b2482e54-877d-4d49-aac0-da92fe608680" />
